### PR TITLE
Fix logic error that caused infinite loop

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1191,12 +1191,12 @@ impl<T: Iterator<Item=char>> Scanner<T> {
             self.lookahead(4);
 
             if self.mark.col == 0 &&
-                ((self.buffer[0] == '-') &&
+                (((self.buffer[0] == '-') &&
                 (self.buffer[1] == '-') &&
                 (self.buffer[2] == '-')) ||
                 ((self.buffer[0] == '.') &&
                 (self.buffer[1] == '.') &&
-                (self.buffer[2] == '.')) &&
+                (self.buffer[2] == '.'))) &&
                 is_blankz(self.buffer[3]) {
                     return Err(ScanError::new(start_mark,
                         "while scanning a quoted scalar, found unexpected document indicator"));
@@ -1381,12 +1381,12 @@ impl<T: Iterator<Item=char>> Scanner<T> {
             self.lookahead(4);
 
             if self.mark.col == 0 &&
-                ((self.buffer[0] == '-') &&
+                (((self.buffer[0] == '-') &&
                  (self.buffer[1] == '-') &&
                  (self.buffer[2] == '-')) ||
                     ((self.buffer[0] == '.') &&
                      (self.buffer[1] == '.') &&
-                     (self.buffer[2] == '.')) &&
+                     (self.buffer[2] == '.'))) &&
                     is_blankz(self.buffer[3]) {
                         break;
                     }

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -476,4 +476,12 @@ a1: &DEFAULT
         let s = "{-";
         assert!(YamlLoader::load_from_str(&s).is_err());
     }
+
+    #[test]
+    fn test_bad_docstart() {
+        assert!(YamlLoader::load_from_str("---This used to cause an infinite loop").is_ok());
+        assert_eq!(YamlLoader::load_from_str("----"), Ok(vec![Yaml::String(String::from("----"))]));
+        assert_eq!(YamlLoader::load_from_str("--- #here goes a comment"), Ok(vec![Yaml::Null]));
+        assert_eq!(YamlLoader::load_from_str("---- #here goes a comment"), Ok(vec![Yaml::String(String::from("----"))]));
+    }
 }


### PR DESCRIPTION
Hey, after #23 I played a bit around with malformed input.
`----` actually caused an infinite loop leaking memory.
Here is a fix to that.

cheers