### PR TITLE
add `into_` counterparts for all `as_` methods

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -339,6 +339,30 @@ impl Index<usize> for Yaml {
     }
 }
 
+impl IntoIterator for Yaml {
+    type Item = Yaml;
+    type IntoIter = YamlIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        YamlIter {yaml: self, index: 0}
+    }
+}
+
+pub struct YamlIter {
+    yaml: Yaml,
+    index: usize,
+}
+
+impl Iterator for YamlIter {
+    type Item = Yaml;
+
+    fn next(&mut self) -> Option<Yaml> {
+        let result = self.yaml[self.index].clone();
+        self.index += 1;
+        Some(result)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use yaml::*;
@@ -539,33 +563,27 @@ a1: &DEFAULT
 - !!bool false
 - 0xFF 
 - 0o77
-- [ 0xF, 0xF ]
 - +12345
-- [ true, false ]
 ";
-        let out = YamlLoader::load_from_str(&s).unwrap();
-        let doc = &out[0]; 
+        let mut out = YamlLoader::load_from_str(&s).unwrap().into_iter(); 
+        let mut doc = out.next().unwrap().into_iter();
         
-        assert_eq!(doc[0].clone().into_string().unwrap(), "string");
-        assert_eq!(doc[1].clone().into_string().unwrap(), "string");
-        assert_eq!(doc[2].clone().into_string().unwrap(), "string");
-        assert_eq!(doc[3].clone().into_i64().unwrap(), 123);
-        assert_eq!(doc[4].clone().into_i64().unwrap(), -321);
-        assert_eq!(doc[5].clone().into_f64().unwrap(), 1.23);
-        assert_eq!(doc[6].clone().into_f64().unwrap(), -1e4);
-        assert_eq!(doc[7].clone().into_bool().unwrap(), true);
-        assert_eq!(doc[8].clone().into_bool().unwrap(), false);
-        assert_eq!(doc[9].clone().into_string().unwrap(), "0");
-        assert_eq!(doc[10].clone().into_i64().unwrap(), 100);
-        assert_eq!(doc[11].clone().into_f64().unwrap(), 2.0);
-        assert_eq!(doc[12].clone().into_bool().unwrap(), true);
-        assert_eq!(doc[13].clone().into_bool().unwrap(), false);
-        assert_eq!(doc[14].clone().into_i64().unwrap(), 255);
-        assert_eq!(doc[15].clone().into_i64().unwrap(), 63);
-        assert_eq!(doc[16][0].clone().into_i64().unwrap(), 15);
-        assert_eq!(doc[16][1].clone().into_i64().unwrap(), 15);
-        assert_eq!(doc[17].clone().into_i64().unwrap(), 12345);
-        assert!(doc[18][0].clone().into_bool().unwrap());
-        assert!(!doc[18][1].clone().into_bool().unwrap());
+        assert_eq!(doc.next().unwrap().into_string().unwrap(), "string");
+        assert_eq!(doc.next().unwrap().into_string().unwrap(), "string");
+        assert_eq!(doc.next().unwrap().into_string().unwrap(), "string");
+        assert_eq!(doc.next().unwrap().into_i64().unwrap(), 123);
+        assert_eq!(doc.next().unwrap().into_i64().unwrap(), -321);
+        assert_eq!(doc.next().unwrap().into_f64().unwrap(), 1.23);
+        assert_eq!(doc.next().unwrap().into_f64().unwrap(), -1e4);
+        assert_eq!(doc.next().unwrap().into_bool().unwrap(), true);
+        assert_eq!(doc.next().unwrap().into_bool().unwrap(), false);
+        assert_eq!(doc.next().unwrap().into_string().unwrap(), "0");
+        assert_eq!(doc.next().unwrap().into_i64().unwrap(), 100);
+        assert_eq!(doc.next().unwrap().into_f64().unwrap(), 2.0);
+        assert_eq!(doc.next().unwrap().into_bool().unwrap(), true);
+        assert_eq!(doc.next().unwrap().into_bool().unwrap(), false);
+        assert_eq!(doc.next().unwrap().into_i64().unwrap(), 255);
+        assert_eq!(doc.next().unwrap().into_i64().unwrap(), 63); 
+        assert_eq!(doc.next().unwrap().into_i64().unwrap(), 12345); 
     }
 }

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -234,7 +234,7 @@ pub fn $name(self) -> Option<$t> {
     }
 }
     );
-); 
+);
 
 impl Yaml {
     define_as!(as_bool, bool, Boolean);
@@ -245,7 +245,7 @@ impl Yaml {
     define_as_ref!(as_vec, &Array, Array);
 
     define_into!(into_bool, bool, Boolean);
-    define_into!(into_i64, i64, Integer); 
+    define_into!(into_i64, i64, Integer);
     define_into!(into_string, String, String);
     define_into!(into_hash, Hash, Hash);
     define_into!(into_vec, Array, Array);
@@ -344,22 +344,21 @@ impl IntoIterator for Yaml {
     type IntoIter = YamlIter;
 
     fn into_iter(self) -> Self::IntoIter {
-        YamlIter {yaml: self, index: 0}
+        let mut yaml = self.into_vec().unwrap_or(vec![]);
+        yaml.reverse();
+        YamlIter {yaml: yaml}
     }
 }
 
 pub struct YamlIter {
-    yaml: Yaml,
-    index: usize,
+    yaml: Vec<Yaml>,
 }
 
 impl Iterator for YamlIter {
     type Item = Yaml;
 
     fn next(&mut self) -> Option<Yaml> {
-        let result = self.yaml[self.index].clone();
-        self.index += 1;
-        Some(result)
+        self.yaml.pop()
     }
 }
 
@@ -540,7 +539,7 @@ a1: &DEFAULT
         assert!(YamlLoader::load_from_str("---This used to cause an infinite loop").is_ok());
         assert_eq!(YamlLoader::load_from_str("----"), Ok(vec![Yaml::String(String::from("----"))]));
         assert_eq!(YamlLoader::load_from_str("--- #here goes a comment"), Ok(vec![Yaml::Null]));
-        assert_eq!(YamlLoader::load_from_str("---- #here goes a comment"), Ok(vec![Yaml::String(String::from("----"))])); 
+        assert_eq!(YamlLoader::load_from_str("---- #here goes a comment"), Ok(vec![Yaml::String(String::from("----"))]));
     }
 
     #[test]
@@ -561,13 +560,13 @@ a1: &DEFAULT
 - !!float 2
 - !!bool true
 - !!bool false
-- 0xFF 
+- 0xFF
 - 0o77
 - +12345
 ";
-        let mut out = YamlLoader::load_from_str(&s).unwrap().into_iter(); 
+        let mut out = YamlLoader::load_from_str(&s).unwrap().into_iter();
         let mut doc = out.next().unwrap().into_iter();
-        
+
         assert_eq!(doc.next().unwrap().into_string().unwrap(), "string");
         assert_eq!(doc.next().unwrap().into_string().unwrap(), "string");
         assert_eq!(doc.next().unwrap().into_string().unwrap(), "string");
@@ -583,7 +582,7 @@ a1: &DEFAULT
         assert_eq!(doc.next().unwrap().into_bool().unwrap(), true);
         assert_eq!(doc.next().unwrap().into_bool().unwrap(), false);
         assert_eq!(doc.next().unwrap().into_i64().unwrap(), 255);
-        assert_eq!(doc.next().unwrap().into_i64().unwrap(), 63); 
-        assert_eq!(doc.next().unwrap().into_i64().unwrap(), 12345); 
+        assert_eq!(doc.next().unwrap().into_i64().unwrap(), 63);
+        assert_eq!(doc.next().unwrap().into_i64().unwrap(), 12345);
     }
 }

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -4,6 +4,7 @@ use std::string;
 use std::i64;
 use std::str::FromStr;
 use std::mem;
+use std::vec;
 use parser::*;
 use scanner::{TScalarStyle, ScanError, TokenType};
 
@@ -344,21 +345,19 @@ impl IntoIterator for Yaml {
     type IntoIter = YamlIter;
 
     fn into_iter(self) -> Self::IntoIter {
-        let mut yaml = self.into_vec().unwrap_or(vec![]);
-        yaml.reverse();
-        YamlIter {yaml: yaml}
+        YamlIter {yaml: self.into_vec().unwrap_or(vec![]).into_iter()}
     }
 }
 
 pub struct YamlIter {
-    yaml: Vec<Yaml>,
+    yaml: vec::IntoIter<Yaml>,
 }
 
 impl Iterator for YamlIter {
     type Item = Yaml;
 
     fn next(&mut self) -> Option<Yaml> {
-        self.yaml.pop()
+        self.yaml.next()
     }
 }
 


### PR DESCRIPTION
fix #28 