### PR TITLE
Allow range of linked-hash-map versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ preserve_order = ["linked-hash-map"]
 
 [dependencies]
 clippy = { version = "^0.*", optional = true }
-linked-hash-map = { version = "0.0.9", optional = true }
+linked-hash-map = { version = ">=0.0.9, <0.4", optional = true }


### PR DESCRIPTION
The newer versions provide an IntoIterator implementation which I need. This is not a breaking change because yaml-rust will continue to work with the old versions of linked-hash-map.