### PR TITLE
reexporting linked hashmap for convenience

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@
 
 #[cfg(feature = "preserve_order")]
 extern crate linked_hash_map;
+#[cfg(feature = "preserve_order")]
+pub use linked_hash_map::LinkedHashMap;
 
 pub mod yaml;
 pub mod scanner;


### PR DESCRIPTION
hey there,
what do you think of this: it would be convenient to reexport the `LinkedHashMap` struct, otherwise users of that feature will have to add the crate themselves. 

thanks :D