### PR TITLE
Introduce traits for types produced by the parser.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -75,10 +75,10 @@ pub struct Parser<T> {
 }
 
 pub trait EventReceiver {
-    fn on_event(&mut self, ev: &Event);
+    fn on_event(&mut self, ev: &Event, mark: Marker);
 }
 
-pub type ParseResult = Result<Event, ScanError>;
+pub type ParseResult = Result<(Event, Marker), ScanError>;
 
 impl<T: Iterator<Item=char>> Parser<T> {
     pub fn new(src: T) -> Parser<T> {
@@ -123,13 +123,13 @@ impl<T: Iterator<Item=char>> Parser<T> {
     }
 
     fn parse<R: EventReceiver>(&mut self, recv: &mut R)
-        -> ParseResult {
+        -> Result<Event, ScanError> {
         if self.state == State::End {
             return Ok(Event::StreamEnd);
         }
-        let ev = try!(self.state_machine());
+        let (ev, mark) = try!(self.state_machine());
         // println!("EV {:?}", ev);
-        recv.on_event(&ev);
+        recv.on_event(&ev, mark);
         Ok(ev)
     }
 
@@ -142,13 +142,13 @@ impl<T: Iterator<Item=char>> Parser<T> {
 
         if self.scanner.stream_ended() {
             // XXX has parsed?
-            recv.on_event(&Event::StreamEnd);
+            recv.on_event(&Event::StreamEnd, self.scanner.mark());
             return Ok(());
         }
         loop {
             let ev = try!(self.parse(recv));
             if ev == Event::StreamEnd {
-                recv.on_event(&Event::StreamEnd);
+                recv.on_event(&Event::StreamEnd, self.scanner.mark());
                 return Ok(());
             }
             // clear anchors before a new document
@@ -269,7 +269,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
             TokenType::StreamStart(_) => {
                 self.state = State::ImplicitDocumentStart;
                 self.skip();
-                Ok(Event::StreamStart)
+                Ok((Event::StreamStart, tok.0))
             },
             _ => Err(ScanError::new(tok.0,
                     "did not find expected <stream-start>")),
@@ -289,7 +289,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
             TokenType::StreamEnd => {
                 self.state = State::End;
                 self.skip();
-                Ok(Event::StreamEnd)
+                Ok((Event::StreamEnd, tok.0))
             },
             TokenType::VersionDirective(..)
                 | TokenType::TagDirective(..)
@@ -301,7 +301,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                 try!(self.parser_process_directives());
                 self.push_state(State::DocumentEnd);
                 self.state = State::BlockNode;
-                Ok(Event::DocumentStart)
+                Ok((Event::DocumentStart, tok.0))
             },
             _ => {
                 // explicit document
@@ -341,7 +341,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
         self.push_state(State::DocumentEnd);
         self.state = State::DocumentContent;
         self.skip();
-        Ok(Event::DocumentStart)
+        Ok((Event::DocumentStart, tok.0))
     }
 
     fn document_content(&mut self) -> ParseResult {
@@ -354,7 +354,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                 |TokenType::StreamEnd => {
                     self.pop_state();
                     // empty scalar
-                    Ok(Event::empty_scalar())
+                    Ok((Event::empty_scalar(), tok.0))
                 },
             _ => {
                 self.parse_node(true, false)
@@ -374,7 +374,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
 
         // TODO tag handling
         self.state = State::DocumentStart;
-        Ok(Event::DocumentEnd)
+        Ok((Event::DocumentEnd, tok.0))
     }
 
     fn register_anchor(&mut self, name: &str, _: &Marker) -> Result<usize, ScanError> {
@@ -399,7 +399,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                 self.skip();
                 match self.anchors.get(&name) {
                     None => return Err(ScanError::new(tok.0, "while parsing node, found unknown anchor")),
-                    Some(id) => return Ok(Event::Alias(*id))
+                    Some(id) => return Ok((Event::Alias(*id), tok.0))
                 }
             },
             TokenType::Anchor(name) => {
@@ -427,33 +427,33 @@ impl<T: Iterator<Item=char>> Parser<T> {
         match tok.1 {
             TokenType::BlockEntry if indentless_sequence => {
                 self.state = State::IndentlessSequenceEntry;
-                Ok(Event::SequenceStart(anchor_id))
+                Ok((Event::SequenceStart(anchor_id), tok.0))
             },
             TokenType::Scalar(style, v) => {
                 self.pop_state();
                 self.skip();
-                Ok(Event::Scalar(v, style, anchor_id, tag))
+                Ok((Event::Scalar(v, style, anchor_id, tag), tok.0))
             },
             TokenType::FlowSequenceStart => {
                 self.state = State::FlowSequenceFirstEntry;
-                Ok(Event::SequenceStart(anchor_id))
+                Ok((Event::SequenceStart(anchor_id), tok.0))
             },
             TokenType::FlowMappingStart => {
                 self.state = State::FlowMappingFirstKey;
-                Ok(Event::MappingStart(anchor_id))
+                Ok((Event::MappingStart(anchor_id), tok.0))
             },
             TokenType::BlockSequenceStart if block => {
                 self.state = State::BlockSequenceFirstEntry;
-                Ok(Event::SequenceStart(anchor_id))
+                Ok((Event::SequenceStart(anchor_id), tok.0))
             },
             TokenType::BlockMappingStart if block => {
                 self.state = State::BlockMappingFirstKey;
-                Ok(Event::MappingStart(anchor_id))
+                Ok((Event::MappingStart(anchor_id), tok.0))
             },
             // ex 7.2, an empty scalar can follow a secondary tag
             _ if tag.is_some() || anchor_id > 0 => {
                 self.pop_state();
-                Ok(Event::empty_scalar_with_anchor(anchor_id, tag))
+                Ok((Event::empty_scalar_with_anchor(anchor_id, tag), tok.0))
             },
             _ => { Err(ScanError::new(tok.0, "while parsing a node, did not find expected node content")) }
         }
@@ -478,7 +478,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                         => {
                             self.state = State::BlockMappingValue;
                             // empty scalar
-                            Ok(Event::empty_scalar())
+                            Ok((Event::empty_scalar(), tok.0))
                         }
                     _ => {
                         self.push_state(State::BlockMappingValue);
@@ -489,12 +489,12 @@ impl<T: Iterator<Item=char>> Parser<T> {
             // XXX(chenyh): libyaml failed to parse spec 1.2, ex8.18
             TokenType::Value => {
                 self.state = State::BlockMappingValue;
-                Ok(Event::empty_scalar())
+                Ok((Event::empty_scalar(), tok.0))
             },
             TokenType::BlockEnd => {
                 self.pop_state();
                 self.skip();
-                Ok(Event::MappingEnd)
+                Ok((Event::MappingEnd, tok.0))
             },
             _ => {
                 Err(ScanError::new(tok.0, "while parsing a block mapping, did not find expected key"))
@@ -513,7 +513,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                             => {
                                 self.state = State::BlockMappingKey;
                                 // empty scalar
-                                Ok(Event::empty_scalar())
+                                Ok((Event::empty_scalar(), tok.0))
                             }
                         _ => {
                             self.push_state(State::BlockMappingKey);
@@ -524,7 +524,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                 _ => {
                     self.state = State::BlockMappingKey;
                     // empty scalar
-                    Ok(Event::empty_scalar())
+                    Ok((Event::empty_scalar(), tok.0))
                 }
             }
     }
@@ -555,7 +555,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                         | TokenType::FlowEntry
                         | TokenType::FlowMappingEnd => {
                         self.state = State::FlowMappingValue;
-                        return Ok(Event::empty_scalar());
+                        return Ok((Event::empty_scalar(), tok.0));
                     },
                     _ => {
                         self.push_state(State::FlowMappingValue);
@@ -565,7 +565,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
             // XXX libyaml fail ex 7.3, empty key
             } else if tok.1 == TokenType::Value {
                 self.state = State::FlowMappingValue;
-                return Ok(Event::empty_scalar());
+                return Ok((Event::empty_scalar(), tok.0));
             } else if tok.1 != TokenType::FlowMappingEnd {
                 self.push_state(State::FlowMappingEmptyValue);
                 return self.parse_node(false, false);
@@ -574,14 +574,14 @@ impl<T: Iterator<Item=char>> Parser<T> {
 
         self.pop_state();
         self.skip();
-        Ok(Event::MappingEnd)
+        Ok((Event::MappingEnd, tok.0))
     }
 
     fn flow_mapping_value(&mut self, empty: bool) -> ParseResult {
         let tok = try!(self.peek());
         if empty {
             self.state = State::FlowMappingKey;
-            return Ok(Event::empty_scalar());
+            return Ok((Event::empty_scalar(), tok.0));
         }
 
         if tok.1 == TokenType::Value {
@@ -598,7 +598,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
         }
 
         self.state = State::FlowMappingKey;
-        Ok(Event::empty_scalar())
+        Ok((Event::empty_scalar(), tok.0))
     }
 
     fn flow_sequence_entry(&mut self, first: bool) -> ParseResult {
@@ -613,7 +613,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
             TokenType::FlowSequenceEnd => {
                 self.pop_state();
                 self.skip();
-                return Ok(Event::SequenceEnd);
+                return Ok((Event::SequenceEnd, tok.0));
             },
             TokenType::FlowEntry if !first => {
                 self.skip();
@@ -629,12 +629,12 @@ impl<T: Iterator<Item=char>> Parser<T> {
             TokenType::FlowSequenceEnd => {
                 self.pop_state();
                 self.skip();
-                Ok(Event::SequenceEnd)
+                Ok((Event::SequenceEnd, tok.0))
             },
             TokenType::Key => {
                 self.state = State::FlowSequenceEntryMappingKey;
                 self.skip();
-                Ok(Event::MappingStart(0))
+                Ok((Event::MappingStart(0), tok.0))
             }
             _ => {
                 self.push_state(State::FlowSequenceEntry);
@@ -647,7 +647,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
         let mut tok = try!(self.peek());
         if tok.1 != TokenType::BlockEntry {
             self.pop_state();
-            return Ok(Event::SequenceEnd);
+            return Ok((Event::SequenceEnd, tok.0));
         }
 
         self.skip();
@@ -658,7 +658,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                 | TokenType::Value
                 | TokenType::BlockEnd => {
                 self.state = State::IndentlessSequenceEntry;
-                Ok(Event::empty_scalar())
+                Ok((Event::empty_scalar(), tok.0))
             },
             _ => {
                 self.push_state(State::IndentlessSequenceEntry);
@@ -679,7 +679,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
             TokenType::BlockEnd => {
                 self.pop_state();
                 self.skip();
-                Ok(Event::SequenceEnd)
+                Ok((Event::SequenceEnd, tok.0))
             },
             TokenType::BlockEntry => {
                 self.skip();
@@ -688,7 +688,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                     TokenType::BlockEntry
                         | TokenType::BlockEnd => {
                         self.state = State::BlockSequenceEntry;
-                        Ok(Event::empty_scalar())
+                        Ok((Event::empty_scalar(), tok.0))
                     },
                     _ => {
                         self.push_state(State::BlockSequenceEntry);
@@ -712,7 +712,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                 | TokenType::FlowSequenceEnd => {
                     self.skip();
                     self.state = State::FlowSequenceEntryMappingValue;
-                    Ok(Event::empty_scalar())
+                    Ok((Event::empty_scalar(), tok.0))
             },
             _ => {
                 self.push_state(State::FlowSequenceEntryMappingValue);
@@ -733,7 +733,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
                         TokenType::FlowEntry
                             | TokenType::FlowSequenceEnd => {
                                 self.state = State::FlowSequenceEntryMappingEnd;
-                                Ok(Event::empty_scalar())
+                                Ok((Event::empty_scalar(), tok.0))
                         },
                         _ => {
                             self.push_state(State::FlowSequenceEntryMappingEnd);
@@ -743,13 +743,13 @@ impl<T: Iterator<Item=char>> Parser<T> {
             },
             _ => {
                 self.state = State::FlowSequenceEntryMappingEnd;
-                Ok(Event::empty_scalar())
+                Ok((Event::empty_scalar(), tok.0))
             }
         }
     }
 
     fn flow_sequence_entry_mapping_end(&mut self) -> ParseResult {
         self.state = State::FlowSequenceEntry;
-        Ok(Event::MappingEnd)
+        Ok((Event::MappingEnd, self.scanner.mark()))
     }
 }

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -6,7 +6,39 @@ use std::str::FromStr;
 use std::mem;
 use std::vec;
 use parser::*;
-use scanner::{TScalarStyle, ScanError, TokenType};
+use scanner::{TScalarStyle, ScanError, TokenType, Marker};
+
+
+pub trait Document: Sized {
+    type Item: Item;
+    type Sequence: Sequence<Item=Self::Item>;
+    type Map: Map<Item=Self::Item>;
+
+    fn create(item: Self::Item) -> Self;
+}
+
+pub trait Item: Clone + Sized {
+    fn create_scalar(value: &str, style: TScalarStyle,
+                     tag: &Option<TokenType>, mark: Marker) -> Self;
+    fn create_bad_value() -> Self;
+}
+
+pub trait Sequence: Clone + Sized {
+    type Item: Item;
+
+    fn create(mark: Marker) -> Self;
+    fn push(&mut self, item: Self::Item);
+    fn finalize(self) -> Self::Item;
+}
+
+pub trait Map: Clone + Sized {
+    type Item: Item;
+
+    fn create(mark: Marker) -> Self;
+    fn insert(&mut self, key: Self::Item, value: Self::Item);
+    fn finalize(self) -> Self::Item;
+}
+
 
 /// A YAML node is stored as this `Yaml` enumeration, which provides an easy way to
 /// access your YAML document.
@@ -58,47 +90,182 @@ pub enum Yaml {
     BadValue,
 }
 
+impl Document for Yaml {
+    type Item = Self;
+    type Sequence = Array;
+    type Map = Hash;
+
+    fn create(item: Self) -> Self { item }
+}
+
+impl Item for Yaml {
+    fn create_scalar(v: &str, style: TScalarStyle,
+                     tag: &Option<TokenType>, _mark: Marker) -> Self {
+        if style != TScalarStyle::Plain {
+            Yaml::String(v.into())
+        } else if let Some(TokenType::Tag(ref handle, ref suffix)) = *tag {
+            // XXX tag:yaml.org,2002:
+            if handle == "!!" {
+                match suffix.as_ref() {
+                    "bool" => {
+                        // "true" or "false"
+                        match v.parse::<bool>() {
+                            Err(_) => Yaml::BadValue,
+                            Ok(v) => Yaml::Boolean(v)
+                        }
+                    },
+                    "int" => {
+                        match v.parse::<i64>() {
+                            Err(_) => Yaml::BadValue,
+                            Ok(v) => Yaml::Integer(v)
+                        }
+                    },
+                    "float" => {
+                        match v.parse::<f64>() {
+                            Err(_) => Yaml::BadValue,
+                            Ok(_) => Yaml::Real(v.into())
+                        }
+                    },
+                    "null" => {
+                        match v.as_ref() {
+                            "~" | "null" => Yaml::Null,
+                            _ => Yaml::BadValue,
+                        }
+                    }
+                    _  => Yaml::String(v.into()),
+                }
+            } else {
+                Yaml::String(v.into())
+            }
+        } else {
+            // Datatype is not specified, or unrecognized
+            Yaml::from_str(v.as_ref())
+        }
+    }
+
+    fn create_bad_value() -> Self {
+        Yaml::BadValue
+    }
+}
+
+
 pub type Array = Vec<Yaml>;
+
+impl Sequence for Array {
+    type Item = Yaml;
+
+    fn create(_mark: Marker) -> Self {
+        Vec::new()
+    }
+
+    fn push(&mut self, item: Yaml) {
+        self.push(item)
+    }
+
+    fn finalize(self) -> Yaml {
+        Yaml::Array(self)
+    }
+}
+
 
 #[cfg(not(feature = "preserve_order"))]
 pub type Hash = BTreeMap<Yaml, Yaml>;
 #[cfg(feature = "preserve_order")]
 pub type Hash = ::linked_hash_map::LinkedHashMap<Yaml, Yaml>;
 
-pub struct YamlLoader {
-    docs: Vec<Yaml>,
-    // states
-    // (current node, anchor_id) tuple
-    doc_stack: Vec<(Yaml, usize)>,
-    key_stack: Vec<Yaml>,
-    anchor_map: BTreeMap<usize, Yaml>,
+impl Map for Hash {
+    type Item = Yaml;
+
+    fn create(_mark: Marker) -> Self {
+        Hash::new()
+    }
+
+    fn insert(&mut self, key: Yaml, value: Yaml) {
+        self.insert(key, value);
+    }
+
+    fn finalize(self) -> Yaml {
+        Yaml::Hash(self)
+    }
 }
 
-impl EventReceiver for YamlLoader {
-    fn on_event(&mut self, ev: &Event) {
+
+enum Node<D: Document> {
+    Scalar(D::Item),
+    Array(D::Sequence),
+    Hash(D::Map),
+    BadValue,
+}
+
+impl<D: Document> Node<D> {
+    pub fn is_badvalue(&self) -> bool {
+        match *self {
+            Node::BadValue => true,
+            _ => false
+        }
+    }
+
+    fn into_item(self) -> D::Item {
+        match self {
+            Node::Scalar(item) => item,
+            Node::Array(item) => item.finalize(),
+            Node::Hash(item) => item.finalize(),
+            Node::BadValue => <D::Item as Item>::create_bad_value()
+        }
+    }
+}
+
+impl<D: Document> Clone for Node<D> {
+    fn clone(&self) -> Self {
+        match *self {
+            Node::Scalar(ref item) => Node::Scalar(item.clone()),
+            Node::Array(ref item) => Node::Array(item.clone()),
+            Node::Hash(ref item) => Node::Hash(item.clone()),
+            Node::BadValue => Node::BadValue
+        }
+    }
+}
+
+pub type YamlLoader = GenericYamlLoader<Yaml>;
+
+pub struct GenericYamlLoader<D: Document> {
+    docs: Vec<D>,
+    // states
+    // (current node, anchor_id) tuple
+    doc_stack: Vec<(Node<D>, usize)>,
+    key_stack: Vec<Node<D>>,
+    anchor_map: BTreeMap<usize, Node<D>>,
+}
+
+impl<D: Document> EventReceiver for GenericYamlLoader<D> {
+    fn on_event(&mut self, ev: &Event, mark: Marker) {
         // println!("EV {:?}", ev);
         match *ev {
             Event::DocumentStart => {
                 // do nothing
             },
             Event::DocumentEnd => {
-                match self.doc_stack.len() {
+                let node = match self.doc_stack.len() {
                     // empty document
-                    0 => self.docs.push(Yaml::BadValue),
-                    1 => self.docs.push(self.doc_stack.pop().unwrap().0),
+                    0 => Node::BadValue,
+                    1 => self.doc_stack.pop().unwrap().0,
                     _ => unreachable!()
-                }
+                };
+                self.docs.push(D::create(node.into_item()));
             },
             Event::SequenceStart(aid) => {
-                self.doc_stack.push((Yaml::Array(Vec::new()), aid));
+                self.doc_stack.push(
+                    (Node::Array(<D::Sequence as Sequence>::create(mark)),
+                     aid));
             },
             Event::SequenceEnd => {
                 let node = self.doc_stack.pop().unwrap();
                 self.insert_new_node(node);
             },
             Event::MappingStart(aid) => {
-                self.doc_stack.push((Yaml::Hash(Hash::new()), aid));
-                self.key_stack.push(Yaml::BadValue);
+                self.doc_stack.push(
+                    (Node::Hash(<D::Map as Map>::create(mark)), aid));
+                self.key_stack.push(Node::BadValue);
             },
             Event::MappingEnd => {
                 self.key_stack.pop().unwrap();
@@ -106,53 +273,14 @@ impl EventReceiver for YamlLoader {
                 self.insert_new_node(node);
             },
             Event::Scalar(ref v, style, aid, ref tag) => {
-                let node = if style != TScalarStyle::Plain {
-                    Yaml::String(v.clone())
-                } else if let Some(TokenType::Tag(ref handle, ref suffix)) = *tag {
-                    // XXX tag:yaml.org,2002:
-                    if handle == "!!" {
-                        match suffix.as_ref() {
-                            "bool" => {
-                                // "true" or "false"
-                                match v.parse::<bool>() {
-                                    Err(_) => Yaml::BadValue,
-                                    Ok(v) => Yaml::Boolean(v)
-                                }
-                            },
-                            "int" => {
-                                match v.parse::<i64>() {
-                                    Err(_) => Yaml::BadValue,
-                                    Ok(v) => Yaml::Integer(v)
-                                }
-                            },
-                            "float" => {
-                                match v.parse::<f64>() {
-                                    Err(_) => Yaml::BadValue,
-                                    Ok(_) => Yaml::Real(v.clone())
-                                }
-                            },
-                            "null" => {
-                                match v.as_ref() {
-                                    "~" | "null" => Yaml::Null,
-                                    _ => Yaml::BadValue,
-                                }
-                            }
-                            _  => Yaml::String(v.clone()),
-                        }
-                    } else {
-                        Yaml::String(v.clone())
-                    }
-                } else {
-                    // Datatype is not specified, or unrecognized
-                    Yaml::from_str(v.as_ref())
-                };
-
-                self.insert_new_node((node, aid));
+                let item = <D::Item as Item>::create_scalar(v, style, tag,
+                                                            mark);
+                self.insert_new_node((Node::Scalar(item), aid));
             },
             Event::Alias(id) => {
                 let n = match self.anchor_map.get(&id) {
                     Some(v) => v.clone(),
-                    None => Yaml::BadValue,
+                    None => Node::BadValue,
                 };
                 self.insert_new_node((n, 0));
             }
@@ -162,8 +290,8 @@ impl EventReceiver for YamlLoader {
     }
 }
 
-impl YamlLoader {
-    fn insert_new_node(&mut self, node: (Yaml, usize)) {
+impl<D: Document> GenericYamlLoader<D> {
+    fn insert_new_node(&mut self, node: (Node<D>, usize)) {
         // valid anchor id starts from 1
         if node.1 > 0 {
             self.anchor_map.insert(node.1, node.0.clone());
@@ -173,17 +301,17 @@ impl YamlLoader {
         } else {
             let parent = self.doc_stack.last_mut().unwrap();
             match *parent {
-                (Yaml::Array(ref mut v), _) => v.push(node.0),
-                (Yaml::Hash(ref mut h), _) => {
+                (Node::Array(ref mut v), _) => v.push(node.0.into_item()),
+                (Node::Hash(ref mut h), _) => {
                     let mut cur_key = self.key_stack.last_mut().unwrap();
                     // current node is a key
                     if cur_key.is_badvalue() {
                         *cur_key = node.0;
                     // current node is a value
                     } else {
-                        let mut newkey = Yaml::BadValue;
+                        let mut newkey = Node::BadValue;
                         mem::swap(&mut newkey, cur_key);
-                        h.insert(newkey, node.0);
+                        h.insert(newkey.into_item(), node.0.into_item());
                     }
                 },
                 _ => unreachable!(),
@@ -191,8 +319,8 @@ impl YamlLoader {
         }
     }
 
-    pub fn load_from_str(source: &str) -> Result<Vec<Yaml>, ScanError>{
-        let mut loader = YamlLoader {
+    pub fn load_from_str(source: &str) -> Result<Vec<D>, ScanError>{
+        let mut loader = GenericYamlLoader {
             docs: Vec::new(),
             doc_stack: Vec::new(),
             key_stack: Vec::new(),

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -3,7 +3,7 @@
 extern crate yaml_rust;
 
 use yaml_rust::parser::{Parser, EventReceiver, Event};
-use yaml_rust::scanner::TScalarStyle;
+use yaml_rust::scanner::{Marker, TScalarStyle};
 
 #[derive(Clone, PartialEq, PartialOrd, Debug)]
 enum TestEvent {
@@ -23,7 +23,7 @@ struct YamlChecker {
 }
 
 impl EventReceiver for YamlChecker {
-    fn on_event(&mut self, ev: &Event) {
+    fn on_event(&mut self, ev: &Event, _: Marker) {
         let tev = match *ev {
             Event::DocumentStart => TestEvent::OnDocumentStart,
             Event::DocumentEnd => TestEvent::OnDocumentEnd,


### PR DESCRIPTION
This is more a proposal than an actual pull request. It allows replacing `yaml::Yaml` with your own types to produce on the fly during parsing. The main purpose is to allow passing markers for producing contextual errors later. This would fix #22.

There’s no breaking changes except for one big one: In order to pass through the marker, I had to extend the signature of `EventReceiver::on_event()`. Maybe there is a better, non-breaking way?