### PR TITLE
Introduce a new trait for event receivers that want markers.

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use std::mem;
 use std::vec;
 use parser::*;
-use scanner::{TScalarStyle, ScanError, TokenType};
+use scanner::{TScalarStyle, ScanError, TokenType, Marker};
 
 /// A YAML node is stored as this `Yaml` enumeration, which provides an easy way to
 /// access your YAML document.
@@ -74,8 +74,8 @@ pub struct YamlLoader {
     anchor_map: BTreeMap<usize, Yaml>,
 }
 
-impl EventReceiver for YamlLoader {
-    fn on_event(&mut self, ev: &Event) {
+impl MarkedEventReceiver for YamlLoader {
+    fn on_event(&mut self, ev: &Event, _: Marker) {
         // println!("EV {:?}", ev);
         match *ev {
             Event::DocumentStart => {


### PR DESCRIPTION
When preparing the PR for the second part of #40, I suddenly remembered when I hadn’t used the approach to add an extra trait method for `EventReceiver`: If you do use the markers, you have to supply an implementation for `on_event()` even though it will never be used.

Here is an approach that seems better: A new trait `MarkedEventReceiver` whose `on_event()` accepts a marker and is implemented for all `EventReceiver`s.

Apologies for the mess created by my forgetfulness. 