### PR TITLE
Update linked-hash-map to 0.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ preserve_order = ["linked-hash-map"]
 
 [dependencies]
 clippy = { version = "^0.*", optional = true }
-linked-hash-map = { version = ">=0.0.9, <0.4", optional = true }
+linked-hash-map = { version = "0.4", optional = true }


### PR DESCRIPTION
linked-hash-map 0.4 was released, which updates serde to the 0.9 series. This will help downstream crates from having to depend on an older version of serde.