### PR TITLE
Remove warnings about unused items

### DIFF
--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::convert::From;
-use yaml::*;
+use yaml::Yaml;
 
 #[derive(Copy, Clone, Debug)]
 pub enum EmitError {

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::ops::Index;
 use std::string;
 use std::i64;
-use std::str::FromStr;
 use std::mem;
 use std::vec;
 use parser::*;


### PR DESCRIPTION
Ran into a couple of small unused warnings while compiling