### PR TITLE
Upgrade Rust versions in Travis/AppVeyor to working ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: rust
 rust:
-        - 1.8.0
-        - 1.16.0
-        - nightly
+  - 1.8.0
+  - 1.16.0
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
 env:
   global:
     - secure: ZUcdcbS8xbpdII9FSPx7VtoVhEkJhWL2Hb75tDlKDHNhfXqmt1NyB9q/2qXJ5Ulp4MnYXwsI8LsDloR6gvdB4xElay3smuF/neGvMjrqcB15/2p0MSQ+kZjMsNB6mlb5kAlm8ahduXIscppmw/V+m5hn3Vo+RQz/Ng+pzv0nc8KEXPMYrfRFg+a7FaeIbRbb8ir9EfflUSqArLq2hbi2WdhM3hFMcCIAUt6DD4x5ubjEg60OnIof5FDu0mXMXzQvUfHWOeYnsNcD/DLyDnm6FuQEzk37M4EB8op2SdBUeQMQ5abR3i2rd//DZpbTTEjud0PseWohGAwTwL2aoFrqs7uYQMx+vcGlOzAyDUm4VemVUa3F2BECdzU5BiujcKOITJEVUYWongld93arQq34FuXG/TO/T1XrerxfG6LTkTkKS5Vz7W8z6Rloa99WrQLJg1ZJP6itEU7G7KsDFVgRhsg7rz4/dV/2+cV4UvIwd4HlGXKCFlH0SClqvM3/7i/qqCD0689SJW6Zip+ly38MXlGy2s/AmReEasXvFer9JkOEIuPa8QTBNAjDlw7bWXi6neQWBIZU1VhZcSssnrVmEFN8fNklShzpw5DyKCv8jPTx2O6Dw8B/LgIK8uo+eaTXiO6zz/T1c/qEdsYslvxPA2D3F+ONpPU7238ykT4eRog=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: rust
 rust:
-        - 1.0.0
-        - 1.1.0
-        - 1.5.0
+        - 1.8.0
+        - 1.16.0
         - nightly
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 install:
   - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.16.0-i686-pc-windows-gnu.exe'
-  - rust-nightly-i686-pc-windows-gnu.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - rust-1.16.0-i686-pc-windows-gnu.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - SET PATH=%PATH%;C:\MinGW\bin
   - rustc -V

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 install:
-  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.exe'
+  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.16.0-i686-pc-windows-gnu.exe'
   - rust-nightly-i686-pc-windows-gnu.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - SET PATH=%PATH%;C:\MinGW\bin


### PR DESCRIPTION
So recent changes to crates.io have broken the Travis build. See https://users.rust-lang.org/t/crates-io-compatibility-with-old-cargo/9127 for more information, but basically nothing will work with Cargo <0.9 (which corresponds to Rust 1.8). I've therefore removed Rust 1.0/1.1/1.5 from the build matrix. I've added in 1.8 as the first usable version, and 1.16 as the most recent stable, as well as the current beta. 

I've also marked nightly as "allowed to fail", because it does at various points (like today) but this shouldn't break yaml-rust. For that reason, I've switched over AppVeyor to using 1.16 which seems to work fine and won't break randomly like nightly.