### PR TITLE
Arbitrarily-nested hashes/arrays emitted as hash keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaml-rust"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Yuheng Chen <yuhengchen@sensetime.com>"]
 homepage = "http://chyh1990.github.io/yaml-rust/"
 documentation = "http://chyh1990.github.io/yaml-rust/doc/yaml_rust/"

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -136,8 +136,6 @@ fn test_mapvec_legal() {
   //    - 6
   //  ```
 
-  println!("{}", out_str);
-
   YamlLoader::load_from_str(&out_str).unwrap();
 }
 

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -136,6 +136,8 @@ fn test_mapvec_legal() {
   //    - 6
   //  ```
 
+  println!("{}", out_str);
+
   YamlLoader::load_from_str(&out_str).unwrap();
 }
 

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -73,3 +73,69 @@ include!("spec_test.rs.inc");
 //#[test]
 //fn test_hc_alias() {
 //}
+
+#[test]
+fn test_mapvec_legal() {
+  use yaml_rust::yaml::{Array, Hash, Yaml};
+  use yaml_rust::{YamlLoader, YamlEmitter};
+
+  // Emitting a `map<map<seq<_>>, _>` should result in legal yaml that
+  // we can parse.
+
+  let mut key = Array::new();
+  key.push(Yaml::Integer(1));
+  key.push(Yaml::Integer(2));
+  key.push(Yaml::Integer(3));
+
+  let mut keyhash = Hash::new();
+  keyhash.insert(Yaml::String("key".into()), Yaml::Array(key));
+
+  let mut val = Array::new();
+  val.push(Yaml::Integer(4));
+  val.push(Yaml::Integer(5));
+  val.push(Yaml::Integer(6));
+
+  let mut hash = Hash::new();
+  hash.insert(Yaml::Hash(keyhash), Yaml::Array(val));
+
+  let mut out_str = String::new();
+  {
+    let mut emitter = YamlEmitter::new(&mut out_str);
+    emitter.dump(&Yaml::Hash(hash)).unwrap();
+  }
+
+  // At this point, we are tempted to naively render like this:
+  //
+  //  ```yaml
+  //  ---
+  //  {key:
+  //      - 1
+  //      - 2
+  //      - 3}:
+  //    - 4
+  //    - 5
+  //    - 6
+  //  ```
+  //
+  // However, this doesn't work, because the key sequence [1, 2, 3] is
+  // rendered in block mode, which is not legal (as far as I can tell)
+  // inside the flow mode of the key. We need to either fully render
+  // everything that's in a key in flow mode (which may make for some
+  // long lines), or use the explicit map identifier '?': 
+  //
+  //  ```yaml
+  //  ---
+  //  ?
+  //    key:
+  //      - 1
+  //      - 2
+  //      - 3
+  //  :
+  //    - 4
+  //    - 5
+  //    - 6
+  //  ```
+
+  YamlLoader::load_from_str(&out_str).unwrap();
+}
+


### PR DESCRIPTION
Cherry-picked from https://github.com/palfrey/yaml-rust/pull/1:

Currently, heavily nested arrays or hashes used as keys of hashes (such as a hash<hash<array<_>, _>, _>) were either illegally written, or caused an error when attempted to be emitted. This fixes that situation by using the ? ... : YAML mapping form (as shown in example 2.11 [here](http://yaml.org/spec/1.2/spec.html#id2760395)), which is more amenable to writing complex keys.

If the key of a hashmap is not complex (i.e. a number, string, etc), then the emitting code is unchanged.