### PR TITLE
Quotes string starting with a dot

### DIFF
--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -375,7 +375,7 @@ products:
     amount: 4
   "*cookies": 
     amount: 4
-  ".milk":
+  ".milk": 
     amount: 1
   "2.4": real key
   "[1,2,3,4]": array key

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -271,6 +271,7 @@ fn need_quotes(string: &str) -> bool {
     || string == "false"
     || string == "null"
     || string == "~"
+    || string.starts_with('.')
     || string.parse::<i64>().is_ok()
     || string.parse::<f64>().is_ok()
 }
@@ -374,6 +375,8 @@ products:
     amount: 4
   "*cookies": 
     amount: 4
+  ".milk":
+    amount: 1
   "2.4": real key
   "[1,2,3,4]": array key
   "true": bool key


### PR DESCRIPTION
To understand why we want to do this, please refer to this issue on ktmpl repository (a way to have templates for kubernetes):
https://github.com/InQuicker/ktmpl/issues/15

The problem applies only to string used as keys, but given that the emitters right now doesn't differentiate the two cases for string, I think is better to do it also for values instead of introducing branching and/or flag variables (can't think of cleaner solution for now).