### PR TITLE
Make pull parser accessible

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -112,7 +112,7 @@ impl<T: Iterator<Item=char>> Parser<T> {
         match self.current {
             Some(ref x) => Ok(x),
             None => {
-                self.current = Some(self.next()?);
+                self.current = Some(try!(self.next()));
                 self.peek()
             }
         }


### PR DESCRIPTION
The current parser is a push parser that encapsulates a pull parser. It performs a self-validation on the underlying state-machine model - panicking in case the latter is producing a sequence of events that is not valid.

This pull request makes the pull parser accessible for the clients, providing a next() and a peek() method. Pull parsers are more user-friendly than push parsers in general...

Note that it also renames peek() to peek_token(), as it provides a peek() method to the clients.

The push parser stays, performing the self-validation, but now using the pull parser interface.