### PR TITLE
index.html: Use yaml-rust from crates.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@ Rust 1.0.0 and nightly!</p>
 
 <p>Adding the following to the Cargo.toml in your project:</p>
 
-<pre><code>[dependencies.yaml-rust]
-git = "https://github.com/chyh1990/yaml-rust.git"
+<pre><code>[dependencies]
+yaml-rust = "0.3.5"
 </code></pre>
 
 <p>and import using <em>extern crate</em>:</p>


### PR DESCRIPTION
Since it is published as a crate, I guess it makes more sense to use it from there.