### PR TITLE
Add a cause() method to EmitError

### DIFF
--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -17,6 +17,10 @@ impl Error for EmitError {
             EmitError::BadHashmapKey => "bad hashmap key",
         }
     }
+
+    fn cause(&self) -> Option<&Error> {
+        None
+    }
 }
 
 impl Display for EmitError {


### PR DESCRIPTION
This should allow the `EmitError` to be used as a `foreign_link` within an `error_chain`