### PR TITLE
Allow access to the Marker from ScanError

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -60,6 +60,10 @@ impl ScanError {
             info: info.to_owned()
         }
     }
+
+    pub fn marker(&self) -> Marker {
+        self.mark
+    }
 }
 
 impl Error for ScanError {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -61,8 +61,8 @@ impl ScanError {
         }
     }
 
-    pub fn marker(&self) -> Marker {
-        self.mark
+    pub fn marker(&self) -> &Marker {
+        &self.mark
     }
 }
 


### PR DESCRIPTION
This is a simple change to allow the Marker to be gathered from the ScanError struct