### PR TITLE
[WIP] Keep markers in parsed output

### DIFF
--- a/examples/dump_yaml.rs
+++ b/examples/dump_yaml.rs
@@ -11,18 +11,19 @@ fn print_indent(indent: usize) {
     }
 }
 
-fn dump_node(doc: &yaml::Yaml, indent: usize) {
-    match *doc {
-        yaml::Yaml::Array(ref v) => {
+fn dump_node(yaml: &yaml::Yaml, indent: usize) {
+    let doc = &yaml.1;
+    match doc {
+        yaml::Node::Array(ref v) => {
             for x in v {
                 dump_node(x, indent + 1);
             }
         },
-        yaml::Yaml::Hash(ref h) => {
-            for (k, v) in h {
+        yaml::Node::Hash(ref h) => {
+            for (k, yaml::HashItem { value, .. }) in h {
                 print_indent(indent);
                 println!("{:?}:", k);
-                dump_node(v, indent + 1);
+                dump_node(value, indent + 1);
             }
         },
         _ => {

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -156,8 +156,9 @@ impl<'a> YamlEmitter<'a> {
         Ok(())
     }
 
-    fn emit_node(&mut self, node: &Yaml) -> EmitResult {
-        match *node {
+    fn emit_node(&mut self, node: &Node) -> EmitResult {
+
+        match node  {
             Node::Array(ref v) => self.emit_array(v),
             Node::Hash(ref h) => self.emit_hash(h),
             Node::String(ref v) => {
@@ -170,7 +171,7 @@ impl<'a> YamlEmitter<'a> {
                 Ok(())
             },
             Node::Boolean(v) => {
-                if v {
+                if *v {
                     try!(self.writer.write_str("true"));
                 } else {
                     try!(self.writer.write_str("false"));
@@ -232,11 +233,11 @@ impl<'a> YamlEmitter<'a> {
                   try!(write!(self.writer, "\n"));
                   try!(self.write_indent());
                   try!(write!(self.writer, ":"));
-                  try!(self.emit_val(true, v));
+                  try!(self.emit_val(true, &v.value));
                 } else {
                   try!(self.emit_node(k));
                   try!(write!(self.writer, ":"));
-                  try!(self.emit_val(false, v));
+                  try!(self.emit_val(false, &v.value));
                 }
             }
             self.level -= 1;
@@ -248,7 +249,7 @@ impl<'a> YamlEmitter<'a> {
     /// following a ":" or "-", either after a space, or on a new line.
     /// If `inline` is true, then the preceeding characters are distinct
     /// and short enough to respect the compact flag.
-    fn emit_val(&mut self, inline: bool, val: &Yaml) -> EmitResult {
+    fn emit_val(&mut self, inline: bool, val: &Node) -> EmitResult {
         match *val {
             Node::Array(ref v) => {
                 if (inline && self.compact) || v.is_empty() {

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 use std::convert::From;
 use std::error::Error;
-use yaml::{Hash, Yaml};
+use yaml::{Hash, Yaml, Node};
 
 
 #[derive(Copy, Clone, Debug)]
@@ -158,9 +158,9 @@ impl<'a> YamlEmitter<'a> {
 
     fn emit_node(&mut self, node: &Yaml) -> EmitResult {
         match *node {
-            Yaml::Array(ref v) => self.emit_array(v),
-            Yaml::Hash(ref h) => self.emit_hash(h),
-            Yaml::String(ref v) => {
+            Node::Array(ref v) => self.emit_array(v),
+            Node::Hash(ref h) => self.emit_hash(h),
+            Node::String(ref v) => {
                 if need_quotes(v) {
                     try!(escape_str(self.writer, v));
                 }
@@ -169,7 +169,7 @@ impl<'a> YamlEmitter<'a> {
                 }
                 Ok(())
             },
-            Yaml::Boolean(v) => {
+            Node::Boolean(v) => {
                 if v {
                     try!(self.writer.write_str("true"));
                 } else {
@@ -177,15 +177,15 @@ impl<'a> YamlEmitter<'a> {
                 }
                 Ok(())
             },
-            Yaml::Integer(v) => {
+            Node::Integer(v) => {
                 try!(write!(self.writer, "{}", v));
                 Ok(())
             },
-            Yaml::Real(ref v) => {
+            Node::Real(ref v) => {
                 try!(write!(self.writer, "{}", v));
                 Ok(())
             },
-            Yaml::Null | Yaml::BadValue => {
+            Node::Null | Node::BadValue => {
                 try!(write!(self.writer, "~"));
                 Ok(())
             },
@@ -219,7 +219,7 @@ impl<'a> YamlEmitter<'a> {
             self.level += 1;
             for (cnt, (k, v)) in h.iter().enumerate() {
                 let complex_key = match *k {
-                  Yaml::Hash(_) | Yaml::Array(_) => true,
+                  Node::Hash(_) | Node::Array(_) => true,
                   _ => false,
                 };
                 if cnt > 0 {
@@ -250,7 +250,7 @@ impl<'a> YamlEmitter<'a> {
     /// and short enough to respect the compact flag.
     fn emit_val(&mut self, inline: bool, val: &Yaml) -> EmitResult {
         match *val {
-            Yaml::Array(ref v) => {
+            Node::Array(ref v) => {
                 if (inline && self.compact) || v.is_empty() {
                     try!(write!(self.writer, " "));
                 } else {
@@ -261,7 +261,7 @@ impl<'a> YamlEmitter<'a> {
                 }
                 self.emit_array(v)
             },
-            Yaml::Hash(ref h) => {
+            Node::Hash(ref h) => {
                 if (inline && self.compact) || h.is_empty() {
                     try!(write!(self.writer, " "));
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub mod emitter;
 // reexport key APIs
 pub use scanner::ScanError;
 pub use parser::Event;
-pub use yaml::{Yaml, YamlLoader};
+pub use yaml::{Node, Yaml, YamlLoader};
 pub use emitter::{YamlEmitter, EmitError};
 
 #[cfg(test)]

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -20,9 +20,9 @@ pub enum TScalarStyle {
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Ord, Debug, Eq, Hash)]
 pub struct Marker {
-    index: usize,
-    line: usize,
-    col: usize,
+    pub index: usize,
+    pub line: usize,
+    pub col: usize,
 }
 
 impl Marker {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -18,7 +18,7 @@ pub enum TScalarStyle {
     Foled
 }
 
-#[derive(Clone, Copy, PartialEq, Debug, Eq)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Ord, Debug, Eq, Hash)]
 pub struct Marker {
     index: usize,
     line: usize,

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -157,7 +157,7 @@ impl MarkedEventReceiver for YamlLoader {
             Event::DocumentEnd => {
                 match self.doc_stack.len() {
                     // empty document
-                    0 => self.docs.push(Yaml(None, Node::BadValue)),
+                    0 => self.docs.push(Yaml(Some(mark), Node::BadValue)),
                     1 => self.docs.push(self.doc_stack.pop().unwrap().0),
                     _ => unreachable!()
                 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -3,7 +3,7 @@ extern crate yaml_rust;
 extern crate quickcheck;
 
 use quickcheck::TestResult;
-use yaml_rust::{Yaml, YamlLoader, YamlEmitter};
+use yaml_rust::{Node, Yaml, YamlLoader, YamlEmitter};
 use std::error::Error;
 
 quickcheck! {
@@ -11,7 +11,9 @@ quickcheck! {
         let mut out_str = String::new();
         {
             let mut emitter = YamlEmitter::new(&mut out_str);
-            emitter.dump(&Yaml::Array(xs.into_iter().map(Yaml::String).collect())).unwrap();
+
+            let doc = Yaml(None, Node::Array(xs.into_iter().map(|x| Yaml(None, Node::String(x))).collect()));
+            emitter.dump(&doc).unwrap();
         }
         if let Err(err) = YamlLoader::load_from_str(&out_str) {
             return TestResult::error(err.description());

--- a/tests/spec_test.rs
+++ b/tests/spec_test.rs
@@ -76,32 +76,32 @@ include!("spec_test.rs.inc");
 
 #[test]
 fn test_mapvec_legal() {
-  use yaml_rust::yaml::{Array, Hash, Yaml};
+  use yaml_rust::yaml::{Array, Hash, Yaml, Node, HashItem};
   use yaml_rust::{YamlLoader, YamlEmitter};
 
   // Emitting a `map<map<seq<_>>, _>` should result in legal yaml that
   // we can parse.
 
   let mut key = Array::new();
-  key.push(Yaml::Integer(1));
-  key.push(Yaml::Integer(2));
-  key.push(Yaml::Integer(3));
+  key.push(Yaml(None, Node::Integer(1)));
+  key.push(Yaml(None, Node::Integer(2)));
+  key.push(Yaml(None, Node::Integer(3)));
 
   let mut keyhash = Hash::new();
-  keyhash.insert(Yaml::String("key".into()), Yaml::Array(key));
+  keyhash.insert(Node::String("key".into()), HashItem { key_marker: None, value: Yaml(None, Node::Array(key))});
 
   let mut val = Array::new();
-  val.push(Yaml::Integer(4));
-  val.push(Yaml::Integer(5));
-  val.push(Yaml::Integer(6));
+  val.push(Yaml(None, Node::Integer(4)));
+  val.push(Yaml(None, Node::Integer(5)));
+  val.push(Yaml(None, Node::Integer(6)));
 
   let mut hash = Hash::new();
-  hash.insert(Yaml::Hash(keyhash), Yaml::Array(val));
+  hash.insert(Node::Hash(keyhash), HashItem { key_marker: None, value: Yaml(None, Node::Array(val))});
 
   let mut out_str = String::new();
   {
     let mut emitter = YamlEmitter::new(&mut out_str);
-    emitter.dump(&Yaml::Hash(hash)).unwrap();
+    emitter.dump(&Yaml(None, Node::Hash(hash))).unwrap();
   }
 
   // At this point, we are tempted to naively render like this:
@@ -138,4 +138,3 @@ fn test_mapvec_legal() {
 
   YamlLoader::load_from_str(&out_str).unwrap();
 }
-


### PR DESCRIPTION
This work in progress pull request adds the markers to the output of the parser

Changes
1. Renamed `Yaml` to `Node`, introduced `struct Yaml(Option<Marker>, Node)`.
2. Introduced `HashItem`. The key of the `Hash` will stay a Node without a Marker, we store the position of the key in this `HashItem` too.

I'm not very happy with the fact that now you need to use the `.0` and `.1` struct indices to get access to the marker or the node. I'll probably update these.

A question to you @chyh1990, is this something that you would merge eventually? Otherwise I'll be able to live with maintaining a fork for my own purpose.

Closes #103.
