### PR TITLE
Support `Null` and `NULL` as defined by Core schema

### DIFF
--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -185,7 +185,7 @@ impl<'a> YamlEmitter<'a> {
                 Ok(())
             }
             Yaml::Null | Yaml::BadValue => {
-                write!(self.writer, "~")?;
+                write!(self.writer, "null")?;
                 Ok(())
             }
             // XXX(chenyh) Alias
@@ -480,7 +480,7 @@ string1: "no"
 string2: "true"
 string3: "false"
 string4: "~"
-null0: ~
+null0: null
 ? - true
   - false
 : real_bools


### PR DESCRIPTION
According to specification recommended schema, when dealing with null, you can either:

 - accept only `null` according to the [yaml json schema](https://yaml.org/spec/1.2/spec.html#id2803362)
 - ` null | Null | NULL | ~` according to the [yaml core schema](https://yaml.org/spec/1.2/spec.html#id2805071)

When emitting `null` you should always emit the canonical form which is `null`.

At the moment `yaml-rust` accept only `null` and `~`  and emit `~` which was the [Yaml 1.1 spec](https://yaml.org/type/null.html). (I believe it was changed for compatibility reason with JSON)

This PR makes it compatible with the yaml 1.2 core schema by adding support for `Null` and `NULL` and emitting `null`.

(Build is broken at the moment, See fix in https://github.com/chyh1990/yaml-rust/pull/116)