### PR TITLE
Fix handling of indicators in plain scalars to conform to YAML 1.2

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -40,7 +40,7 @@ pub enum Yaml {
     Array(self::Array),
     /// YAML hash, can be accessed as a `LinkedHashMap`.
     ///
-    /// Itertion order will match the order of insertion into the map.
+    /// Insertion order will match the order of insertion into the map.
     Hash(self::Hash),
     /// Alias, not fully supported yet.
     Alias(usize),


### PR DESCRIPTION
YAML 1.2 has special handling of indicators to be compatible with JSON.
The following is equivalent to `{"a": "b"}` (note, no space after `:`):

    {"a":b}

But without the quoted key, a space is required. So the `:` here is part
of the plain scalar:

    {a:b}  # == {"a:b"}

A plain scalar can also start with a `:` as long as it's followed by
"safe" characters:

    {a: :b}  # == {"a": ":b"}

(Fixes #118)

(See #116 for failing build)