### PR TITLE
Add `escape_all_strings` option to `Emitter`

### DIFF
--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -41,6 +41,7 @@ pub struct YamlEmitter<'a> {
     writer: &'a mut fmt::Write,
     best_indent: usize,
     compact: bool,
+    escape_all_strings: bool,
 
     level: isize,
 }
@@ -117,6 +118,7 @@ impl<'a> YamlEmitter<'a> {
             best_indent: 2,
             compact: true,
             level: -1,
+            escape_all_strings: false,
         }
     }
 
@@ -135,6 +137,19 @@ impl<'a> YamlEmitter<'a> {
     /// Determine if this emitter is using 'compact inline notation'.
     pub fn is_compact(&self) -> bool {
         self.compact
+    }
+
+    /// Wrap all `YAML::String` nodes in double-quotes and escape special characters (if any),
+    /// regardless of whether or not they contain special characters.
+    ///
+    /// This maintains typing, ensuring that `example: "0x00"` is not emitted as `example: 0x00`.
+    pub fn escape_all_strings(&mut self, escape_all_strings: bool) {
+        self.escape_all_strings = escape_all_strings
+    }
+
+    /// Determine if this emitter will wrap all strings in double-quotes.
+    pub fn is_escape_all_strings(&self) -> bool {
+        self.escape_all_strings
     }
 
     pub fn dump(&mut self, doc: &Yaml) -> EmitResult {
@@ -161,7 +176,7 @@ impl<'a> YamlEmitter<'a> {
             Yaml::Array(ref v) => self.emit_array(v),
             Yaml::Hash(ref h) => self.emit_hash(h),
             Yaml::String(ref v) => {
-                if need_quotes(v) {
+                if need_quotes(v) | self.escape_all_strings {
                     escape_str(self.writer, v)?;
                 } else {
                     write!(self.writer, "{}", v)?;
@@ -636,6 +651,42 @@ a:
         println!("emitted:\n{}", writer);
 
         assert_eq!(s, writer);
+    }
+
+    #[test]
+    fn test_escape_all_strings() {
+        let s = r#"---
+example: "0x00""#;
+
+        let docs = YamlLoader::load_from_str(&s).unwrap();
+        let doc = &docs[0];
+
+        let mut wr = String::new();
+        {
+            let mut emitter = YamlEmitter::new(&mut wr);
+            assert_eq!(emitter.is_escape_all_strings(), false);
+            emitter.dump(doc).unwrap();
+        }
+
+        assert_eq!(
+            wr,
+            r#"---
+example: 0x00"#
+        );
+
+        let mut wr = String::new();
+        {
+            let mut emitter = YamlEmitter::new(&mut wr);
+            emitter.escape_all_strings(true);
+            assert_eq!(emitter.is_escape_all_strings(), true);
+            emitter.dump(doc).unwrap();
+        }
+
+        assert_eq!(
+            wr,
+            r#"---
+"example": "0x00""#
+        );
     }
 
 }


### PR DESCRIPTION
First of all, thanks for this library. It's been great and has got me out of some sticky situations where `serde` is not flexible enough. Much appreciated.

This PR makes a change to ensure typing between loading and emitting.

### Problem

Consider the following YAML:

```yaml
example: "0x00"
```

After one round of `YamlLoader -> YamlEmitter` the YAML is now:

```yaml
example: 0x00
```

After a second round the YAML is then:

```yaml
example: 0
```

The YAML has now changed significantly and information has been lost.

### Solution

I added an `emitter.escape_all_strings(bool)` function which forces all `YAML::String` nodes to be wrapped in double-quotes.

I would be interested on your opinion on two points:
- I would have used single-quotes, however it seemed much simpler to use double-quotes. I am not a YAML expert and I would be interested to hear of any side-effects of this.
- The key is now wrapped in double-quotes too (e.g., `"example": "0x00"`). I am not sure if this has side-effects too.

Thank you for you time, happy to make changes as you require.