### PR TITLE
Fix emitting hexlike strings without quotes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ matrix:
     - rust: stable
     - rust: beta
     - rust: nightly
-    - rust: 1.17.0
-      script: cargo build
-    - rust: 1.24.1
+    - rust: 1.28.0
     - rust: nightly
       env: CLIPPY
       script: |

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ so it may not be a huge problem for most users.
 * Tag directive
 * Alias while desearilization
 
+## Minimum Rust version policy
+
+This crate's minimum supported `rustc` version is 1.28, as this is the currently known minimum version for [`regex`](https://crates.io/crates/regex#minimum-rust-version-policy) as well.
+
 ## License
 
 Licensed under either of

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 install:
-  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.24.1-i686-pc-windows-gnu.exe'
-  - rust-1.24.1-i686-pc-windows-gnu.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - ps: Start-FileDownload 'https://static.rust-lang.org/dist/rust-1.28.0-i686-pc-windows-gnu.exe'
+  - rust-1.28.0-i686-pc-windows-gnu.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - SET PATH=%PATH%;C:\MinGW\bin
   - rustc -V

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -336,6 +336,7 @@ fn need_quotes(string: &str) -> bool {
         ]
         .contains(&string)
         || string.starts_with('.')
+        || string.starts_with("0x")
         || string.parse::<i64>().is_ok()
         || string.parse::<f64>().is_ok()
 }

--- a/tests/test_round_trip.rs
+++ b/tests/test_round_trip.rs
@@ -2,22 +2,64 @@ extern crate yaml_rust;
 
 use yaml_rust::{Yaml, YamlEmitter, YamlLoader};
 
-fn test_round_trip(original: &Yaml) {
-    let mut out = String::new();
-    YamlEmitter::new(&mut out).dump(original).unwrap();
-    let documents = YamlLoader::load_from_str(&out).unwrap();
+fn roundtrip(original: &Yaml) {
+    let mut emitted = String::new();
+    YamlEmitter::new(&mut emitted).dump(original).unwrap();
+
+    let documents = YamlLoader::load_from_str(&emitted).unwrap();
+    println!("emitted {}", emitted);
+
     assert_eq!(documents.len(), 1);
     assert_eq!(documents[0], *original);
+}
+
+fn double_roundtrip(original: &str) {
+    let parsed = YamlLoader::load_from_str(&original).unwrap();
+
+    let mut serialized = String::new();
+    YamlEmitter::new(&mut serialized).dump(&parsed[0]).unwrap();
+
+    let reparsed = YamlLoader::load_from_str(&serialized).unwrap();
+
+    assert_eq!(parsed, reparsed);
 }
 
 #[test]
 fn test_escape_character() {
     let y = Yaml::String("\x1b".to_owned());
-    test_round_trip(&y);
+    roundtrip(&y);
 }
 
 #[test]
 fn test_colon_in_string() {
     let y = Yaml::String("x: %".to_owned());
-    test_round_trip(&y);
+    roundtrip(&y);
+}
+
+#[test]
+fn test_numberlike_strings() {
+    let docs = [
+        r#"x: "1234""#, r#"x: "01234""#, r#""1234""#,
+        r#""01234""#, r#"" 01234""#, r#""0x1234""#,
+        r#"" 0x1234""#,
+    ];
+
+    for doc in &docs {
+        roundtrip(&Yaml::String(doc.to_string()));
+        double_roundtrip(&doc);
+    }
+}
+
+/// Example from https://github.com/chyh1990/yaml-rust/issues/133
+#[test]
+fn test_issue133() {
+
+    let doc = YamlLoader::load_from_str("\"0x123\"").unwrap().pop().unwrap();
+    assert_eq!(doc, Yaml::String("0x123".to_string()));
+
+    let mut out_str = String::new();
+    YamlEmitter::new(&mut out_str).dump(&doc).unwrap();
+    let doc2 = YamlLoader::load_from_str(&out_str).unwrap().pop().unwrap();
+    assert_eq!(doc, doc2); // This failed because the type has changed to a number now
+
 }


### PR DESCRIPTION
The emitter omitted quotes for strings that start with `0x` those would
subsequently be parsed as strings again. This should fix #133.