### PR TITLE
Emit multi-line string values as block scalars

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -67,7 +67,7 @@ impl Error for ScanError {
         self.info.as_ref()
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         None
     }
 }
@@ -199,7 +199,7 @@ fn is_digit(c: char) -> bool {
 #[inline]
 fn is_alpha(c: char) -> bool {
     match c {
-        '0'...'9' | 'a'...'z' | 'A'...'Z' => true,
+        '0'..='9' | 'a'..='z' | 'A'..='Z' => true,
         '_' | '-' => true,
         _ => false,
     }
@@ -211,9 +211,9 @@ fn is_hex(c: char) -> bool {
 #[inline]
 fn as_hex(c: char) -> u32 {
     match c {
-        '0'...'9' => (c as u32) - ('0' as u32),
-        'a'...'f' => (c as u32) - ('a' as u32) + 10,
-        'A'...'F' => (c as u32) - ('A' as u32) + 10,
+        '0'..='9' => (c as u32) - ('0' as u32),
+        'a'..='f' => (c as u32) - ('a' as u32) + 10,
+        'A'..='F' => (c as u32) - ('A' as u32) + 10,
         _ => unreachable!(),
     }
 }

--- a/tests/test_round_trip.rs
+++ b/tests/test_round_trip.rs
@@ -21,3 +21,15 @@ fn test_colon_in_string() {
     let y = Yaml::String("x: %".to_owned());
     test_round_trip(&y);
 }
+
+#[test]
+fn test_newline() {
+    let y = Yaml::Array(vec![Yaml::String("\n".to_owned())]);
+    test_round_trip(&y);
+}
+
+#[test]
+fn test_crlf() {
+    let y = Yaml::Array(vec![Yaml::String("\r\n".to_owned())]);
+    test_round_trip(&y);
+}


### PR DESCRIPTION
This PR changes the output behavior to emit multi-line string
values as block scalars instead of inline string literals with newline
characters escaped, with the aim of improving the human readability
of the emitted YAML.

For example, `["foo\nbar\nbaz"]` is now emitted as:
```
- |-2
  foo
  bar
  baz
```

To properly handle trailing newlines, this PR also adds a trailing `...`
[document marker](https://yaml.org/spec/1.2/spec.html#marker/document%20end/)
following the `dump` output.

Lastly, this PR fixes a few compile warnings emitted by the latest stable rust.