### PR TITLE
cargo: require linked-hash-map 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/chyh1990/yaml-rust"
 readme = "README.md"
 
 [dependencies]
-linked-hash-map = ">=0.0.9, <0.6"
+linked-hash-map = "0.5"
 
 [dev-dependencies]
 quickcheck = "0.7"


### PR DESCRIPTION
`linked_hash_map::LinkedHashMap` is exposed as the type inside
`Yaml::Hash`. Crates cannot depend on a stable API from this because the
crate has not had a stable API itself over this version range. Just use
0.5 so that `-Z minimal-versions` can work.

See rust-lang/cargo#5657 for discussion about the cargo feature.

---
I suspect more discussion of what's going on here will have to happen. Maybe the best solution is to just hide `LinkedHashMap` behind a wrapper API that can be kept stable in this crate directly?