### PR TITLE
Spellcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ so it may not be a huge problem for most users.
 
 * Encoder
 * Tag directive
-* Alias while desearilization
+* Alias while deserialization
 
 ## Minimum Rust version policy
 

--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -245,7 +245,7 @@ impl<'a> YamlEmitter<'a> {
 
     /// Emit a yaml as a hash or array value: i.e., which should appear
     /// following a ":" or "-", either after a space, or on a new line.
-    /// If `inline` is true, then the preceeding characters are distinct
+    /// If `inline` is true, then the preceding characters are distinct
     /// and short enough to respect the compact flag.
     fn emit_val(&mut self, inline: bool, val: &Yaml) -> EmitResult {
         match *val {
@@ -327,7 +327,7 @@ fn need_quotes(string: &str) -> bool {
         || [
             // http://yaml.org/type/bool.html
             // Note: 'y', 'Y', 'n', 'N', is not quoted deliberately, as in libyaml. PyYAML also parse
-            // them as string, not booleans, although it is volating the YAML 1.1 specification.
+            // them as string, not booleans, although it is violating the YAML 1.1 specification.
             // See https://github.com/dtolnay/serde-yaml/pull/83#discussion_r152628088.
             "yes", "Yes", "YES", "no", "No", "NO", "True", "TRUE", "true", "False", "FALSE",
             "false", "on", "On", "ON", "off", "Off", "OFF",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -349,7 +349,7 @@ impl<T: Iterator<Item = char>> Parser<T> {
             | Token(_, TokenType::TagDirective(..))
             | Token(_, TokenType::DocumentStart) => {
                 // explicit document
-                self._explict_document_start()
+                self._explicit_document_start()
             }
             Token(mark, _) if implicit => {
                 self.parser_process_directives()?;
@@ -359,7 +359,7 @@ impl<T: Iterator<Item = char>> Parser<T> {
             }
             _ => {
                 // explicit document
-                self._explict_document_start()
+                self._explicit_document_start()
             }
         }
     }
@@ -385,7 +385,7 @@ impl<T: Iterator<Item = char>> Parser<T> {
         Ok(())
     }
 
-    fn _explict_document_start(&mut self) -> ParseResult {
+    fn _explicit_document_start(&mut self) -> ParseResult {
         self.parser_process_directives()?;
         match *self.peek_token()? {
             Token(mark, TokenType::DocumentStart) => {
@@ -433,7 +433,7 @@ impl<T: Iterator<Item = char>> Parser<T> {
     }
 
     fn register_anchor(&mut self, name: String, _: &Marker) -> Result<usize, ScanError> {
-        // anchors can be overrided/reused
+        // anchors can be overridden/reused
         // if self.anchors.contains_key(name) {
         //     return Err(ScanError::new(*mark,
         //         "while parsing anchor, found duplicated anchor"));
@@ -704,7 +704,7 @@ impl<T: Iterator<Item = char>> Parser<T> {
             Token(mark, _) if !first => {
                 return Err(ScanError::new(
                     mark,
-                    "while parsing a flow sequence, expectd ',' or ']'",
+                    "while parsing a flow sequence, expected ',' or ']'",
                 ));
             }
             _ => { /* next */ }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1100,7 +1100,7 @@ impl<T: Iterator<Item = char>> Scanner<T> {
                 if self.ch() == '0' {
                     return Err(ScanError::new(
                         start_mark,
-                        "while scanning a block scalar, found an intendation indicator equal to 0",
+                        "while scanning a block scalar, found an indentation indicator equal to 0",
                     ));
                 }
                 increment = (self.ch() as usize) - ('0' as usize);
@@ -1110,7 +1110,7 @@ impl<T: Iterator<Item = char>> Scanner<T> {
             if self.ch() == '0' {
                 return Err(ScanError::new(
                     start_mark,
-                    "while scanning a block scalar, found an intendation indicator equal to 0",
+                    "while scanning a block scalar, found an indentation indicator equal to 0",
                 ));
             }
 
@@ -1200,7 +1200,7 @@ impl<T: Iterator<Item = char>> Scanner<T> {
             self.lookahead(2);
             self.read_break(&mut leading_break);
 
-            // Eat the following intendation spaces and line breaks.
+            // Eat the following indentation spaces and line breaks.
             self.block_scalar_breaks(&mut indent, &mut trailing_breaks)?;
         }
 
@@ -1239,10 +1239,10 @@ impl<T: Iterator<Item = char>> Scanner<T> {
                 max_indent = self.mark.col;
             }
 
-            // Check for a tab character messing the intendation.
+            // Check for a tab character messing the indentation.
             if (*indent == 0 || self.mark.col < *indent) && self.buffer[0] == '\t' {
                 return Err(ScanError::new(self.mark,
-                        "while scanning a block scalar, found a tab character where an intendation space is expected"));
+                        "while scanning a block scalar, found a tab character where an indentation space is expected"));
             }
 
             if !is_break(self.ch()) {
@@ -1384,7 +1384,7 @@ impl<T: Iterator<Item = char>> Scanner<T> {
                             for i in 0..code_length {
                                 if !is_hex(self.buffer[i]) {
                                     return Err(ScanError::new(start_mark,
-                                        "while parsing a quoted scalar, did not find expected hexdecimal number"));
+                                        "while parsing a quoted scalar, did not find expected hexadecimal number"));
                                 }
                                 value = (value << 4) + as_hex(self.buffer[i]);
                             }
@@ -1589,7 +1589,7 @@ impl<T: Iterator<Item = char>> Scanner<T> {
                 self.lookahead(1);
             }
 
-            // check intendation level
+            // check indentation level
             if self.flow_level == 0 && (self.mark.col as isize) < indent {
                 break;
             }
@@ -1608,7 +1608,7 @@ impl<T: Iterator<Item = char>> Scanner<T> {
     fn fetch_key(&mut self) -> ScanResult {
         let start_mark = self.mark;
         if self.flow_level == 0 {
-            // Check if we are allowed to start a new key (not nessesary simple).
+            // Check if we are allowed to start a new key (not necessarily simple).
             if !self.simple_key_allowed {
                 return Err(ScanError::new(
                     self.mark,

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -528,7 +528,7 @@ a1: &DEFAULT
     }
 
     #[test]
-    fn test_bad_hypen() {
+    fn test_bad_hyphen() {
         // See: https://github.com/chyh1990/yaml-rust/issues/23
         let s = "{-";
         assert!(YamlLoader::load_from_str(&s).is_err());


### PR DESCRIPTION
Fix spelling in several places - mostly variable names, error string literals and documentation, although one test function was renamed.