### PR TITLE
Fix erroring clippy lints about if let options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ matrix:
     - rust: nightly
       env: CLIPPY
       script: |
-          if rustup component add clippy-preview; then
-              cargo clippy -- -Dclippy
-          fi
+          rustup component add clippy-preview || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
+          cargo clippy -- -Dclippy
 
 script:
   - cargo build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - rust: nightly
       env: CLIPPY
       script: |
-          rustup component add clippy-preview || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
+          rustup toolchain install nightly -c clippy
           cargo clippy -- -Dclippy
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
     - rust: nightly
       env: CLIPPY
       script: |
-          rustup toolchain install nightly -c clippy
-          cargo clippy -- -Dclippy
+          rustup toolchain install nightly --allow-downgrade --component clippy
+          cargo clippy -- -Dclippy 
 
 script:
   - cargo build

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -289,14 +289,14 @@ impl Yaml {
     pub fn from_str(v: &str) -> Yaml {
         if v.starts_with("0x") {
             let n = i64::from_str_radix(&v[2..], 16);
-            if n.is_ok() {
-                return Yaml::Integer(n.unwrap());
+            if let Ok(integer) = n {
+                return Yaml::Integer(integer);
             }
         }
         if v.starts_with("0o") {
             let n = i64::from_str_radix(&v[2..], 8);
-            if n.is_ok() {
-                return Yaml::Integer(n.unwrap());
+            if let Ok(integer) = n {
+                return Yaml::Integer(integer);
             }
         }
         if v.starts_with('+') && v[1..].parse::<i64>().is_ok() {


### PR DESCRIPTION
It also fixes the issue where clippy wasn't available on some nightlies so this got ran sporadically by using the [new rustup feature](https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html#installing-the-latest-compatible-nightly) to give us the latest nightly that has clippy in it.

The build is still failing, but that's fixed by #145