### PR TITLE
Remove deprecation warnings for rustc 1.41

### DIFF
--- a/src/emitter.rs
+++ b/src/emitter.rs
@@ -17,7 +17,7 @@ impl Error for EmitError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         None
     }
 }
@@ -38,7 +38,7 @@ impl From<fmt::Error> for EmitError {
 }
 
 pub struct YamlEmitter<'a> {
-    writer: &'a mut fmt::Write,
+    writer: &'a mut dyn fmt::Write,
     best_indent: usize,
     compact: bool,
 
@@ -48,7 +48,7 @@ pub struct YamlEmitter<'a> {
 pub type EmitResult = Result<(), EmitError>;
 
 // from serialize::json
-fn escape_str(wr: &mut fmt::Write, v: &str) -> Result<(), fmt::Error> {
+fn escape_str(wr: &mut dyn fmt::Write, v: &str) -> Result<(), fmt::Error> {
     wr.write_str("\"")?;
 
     let mut start = 0;
@@ -111,7 +111,7 @@ fn escape_str(wr: &mut fmt::Write, v: &str) -> Result<(), fmt::Error> {
 }
 
 impl<'a> YamlEmitter<'a> {
-    pub fn new(writer: &'a mut fmt::Write) -> YamlEmitter {
+    pub fn new(writer: &'a mut dyn fmt::Write) -> YamlEmitter {
         YamlEmitter {
             writer,
             best_indent: 2,
@@ -316,12 +316,12 @@ fn need_quotes(string: &str) -> bool {
             | '\"'
             | '\''
             | '\\'
-            | '\0'...'\x06'
+            | '\0'..='\x06'
             | '\t'
             | '\n'
             | '\r'
-            | '\x0e'...'\x1a'
-            | '\x1c'...'\x1f' => true,
+            | '\x0e'..='\x1a'
+            | '\x1c'..='\x1f' => true,
             _ => false,
         })
         || [
@@ -638,5 +638,4 @@ a:
 
         assert_eq!(s, writer);
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,5 +117,4 @@ key1:a2
         assert!(YamlLoader::load_from_str(s).is_err());
         assert!(try_fail(s).is_err());
     }
-
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -67,7 +67,7 @@ impl Error for ScanError {
         self.info.as_ref()
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         None
     }
 }
@@ -199,7 +199,7 @@ fn is_digit(c: char) -> bool {
 #[inline]
 fn is_alpha(c: char) -> bool {
     match c {
-        '0'...'9' | 'a'...'z' | 'A'...'Z' => true,
+        '0'..='9' | 'a'..='z' | 'A'..='Z' => true,
         '_' | '-' => true,
         _ => false,
     }
@@ -211,9 +211,9 @@ fn is_hex(c: char) -> bool {
 #[inline]
 fn as_hex(c: char) -> u32 {
     match c {
-        '0'...'9' => (c as u32) - ('0' as u32),
-        'a'...'f' => (c as u32) - ('a' as u32) + 10,
-        'A'...'F' => (c as u32) - ('A' as u32) + 10,
+        '0'..='9' => (c as u32) - ('0' as u32),
+        'a'..='f' => (c as u32) - ('a' as u32) + 10,
+        'A'..='F' => (c as u32) - ('A' as u32) + 10,
         _ => unreachable!(),
     }
 }

--- a/tests/test_round_trip.rs
+++ b/tests/test_round_trip.rs
@@ -39,8 +39,12 @@ fn test_colon_in_string() {
 #[test]
 fn test_numberlike_strings() {
     let docs = [
-        r#"x: "1234""#, r#"x: "01234""#, r#""1234""#,
-        r#""01234""#, r#"" 01234""#, r#""0x1234""#,
+        r#"x: "1234""#,
+        r#"x: "01234""#,
+        r#""1234""#,
+        r#""01234""#,
+        r#"" 01234""#,
+        r#""0x1234""#,
         r#"" 0x1234""#,
     ];
 
@@ -53,13 +57,14 @@ fn test_numberlike_strings() {
 /// Example from https://github.com/chyh1990/yaml-rust/issues/133
 #[test]
 fn test_issue133() {
-
-    let doc = YamlLoader::load_from_str("\"0x123\"").unwrap().pop().unwrap();
+    let doc = YamlLoader::load_from_str("\"0x123\"")
+        .unwrap()
+        .pop()
+        .unwrap();
     assert_eq!(doc, Yaml::String("0x123".to_string()));
 
     let mut out_str = String::new();
     YamlEmitter::new(&mut out_str).dump(&doc).unwrap();
     let doc2 = YamlLoader::load_from_str(&out_str).unwrap().pop().unwrap();
     assert_eq!(doc, doc2); // This failed because the type has changed to a number now
-
 }


### PR DESCRIPTION
When compiling with Rust 1.41 (stable version as of 2020-01-27) a
number of deprecation warnings are shown.

Fixes: #152 