### PR TITLE
bump linked hashmap to 5.3+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-linked-hash-map = ">=0.0.9, <0.6"
+linked-hash-map = "0.5.3"
 
 [dev-dependencies]
 quickcheck = "0.9"


### PR DESCRIPTION
Older versions of linked-hashmap are unsound so it is better if this repository doesn't depend on those. 

Advisory: https://github.com/RustSec/advisory-db/issues/298

If you need further guidance, you can consult the wg-secure-code on Rust Zulip



