### PR TITLE
Replace linked-hash-map with ritelinked

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-linked-hash-map = "0.5.3"
+ritelinked = "0.2.1"
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! ```toml
 //! [dependencies.yaml-rust]
-//! git = "https://github.com/chyh1990/yaml-rust.git"
+//! yaml-rust = "0.4"
 //! ```
 //!
 //! And this in your crate root:
@@ -44,7 +44,7 @@
     allow(match_same_arms, should_implement_trait)
 )]
 
-extern crate linked_hash_map;
+extern crate ritelinked;
 
 pub mod emitter;
 pub mod parser;

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -1,4 +1,4 @@
-use linked_hash_map::LinkedHashMap;
+use ritelinked::LinkedHashMap;
 use crate::parser::*;
 use crate::scanner::{Marker, ScanError, TScalarStyle, TokenType};
 use std::collections::BTreeMap;


### PR DESCRIPTION
Also see https://github.com/chyh1990/yaml-rust/pull/157

ritelinked is a fork of the popular crate hashlink, provides `LinkedHashMap` & `LinkedHashSet` . You can easily use it on std or no_std environment.