### PR TITLE
introduce `or` function

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -280,6 +280,22 @@ impl Yaml {
             _ => None,
         }
     }
+
+    /// If a value is null or otherwise bad (see variants), consume it and
+    /// replace it with a given value `other`. Otherwise, return self unchanged.
+    ///
+    /// ```
+    /// use yaml_rust::yaml::Yaml;
+    ///
+    /// assert_eq!(Yaml::BadValue.or(Yaml::Integer(3)),  Yaml::Integer(3));
+    /// assert_eq!(Yaml::Integer(3).or(Yaml::BadValue),  Yaml::Integer(3));
+    /// ```
+    pub fn or(self, other: Self) -> Self {
+        match self {
+            Yaml::BadValue | Yaml::Null => other,
+            this => this,
+        }
+    }
 }
 
 #[cfg_attr(feature = "cargo-clippy", allow(should_implement_trait))]
@@ -735,5 +751,11 @@ subcommands3:
     fn test_recursion_depth_check_arrays() {
         let s = "[".repeat(10_000) + &"]".repeat(10_000);
         assert!(YamlLoader::load_from_str(&s).is_err());
+    }
+
+    #[test]
+    fn test_or() {
+        assert_eq!(Yaml::Null.or(Yaml::Integer(3)), Yaml::Integer(3));
+        assert_eq!(Yaml::Integer(3).or(Yaml::Integer(7)), Yaml::Integer(3));
     }
 }

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -296,6 +296,15 @@ impl Yaml {
             this => this,
         }
     }
+
+    /// See `or` for behavior. This performs the same operations, but with
+    /// borrowed values for less linear pipelines.
+    pub fn borrowed_or<'a>(&'a self, other: &'a Self) -> &'a Self {
+        match self {
+            Yaml::BadValue | Yaml::Null => other,
+            this => this,
+        }
+    }
 }
 
 #[cfg_attr(feature = "cargo-clippy", allow(should_implement_trait))]


### PR DESCRIPTION
Similarly to `or` for Rust's options, this patch provides a way to 'override' the value of a Yaml node if it's some form of error.

It's a pretty small patch: if this type of albeit trivial manipulation is beyond the scope of the library, feel free not to merge! Thanks!