### PR TITLE
Allowing tags to be propagated for other events as well

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ branches:
     - master
 
 environment:
-  LLVM_VERSION: 9.0.1
+  LLVM_VERSION: 11.0.0
   PLATFORM: x64
   matrix:
     - channel: stable

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -90,14 +90,14 @@ impl MarkedEventReceiver for YamlLoader {
                     _ => unreachable!(),
                 }
             }
-            Event::SequenceStart(aid) => {
+            Event::SequenceStart(aid, _) => {
                 self.doc_stack.push((Yaml::Array(Vec::new()), aid));
             }
             Event::SequenceEnd => {
                 let node = self.doc_stack.pop().unwrap();
                 self.insert_new_node(node);
             }
-            Event::MappingStart(aid) => {
+            Event::MappingStart(aid, _) => {
                 self.doc_stack.push((Yaml::Hash(Hash::new()), aid));
                 self.key_stack.push(Yaml::BadValue);
             }

--- a/tests/spec_test.rs.inc
+++ b/tests/spec_test.rs.inc
@@ -335,6 +335,8 @@ fn test_ex2_23_various_explicit_tags() {
     assert_next!(v, TestEvent::OnScalar);
     assert_next!(v, TestEvent::OnScalar);
     assert_next!(v, TestEvent::OnScalar);
+    assert_next!(v, TestEvent::OnScalar);
+    assert_next!(v, TestEvent::OnScalar);
     assert_next!(v, TestEvent::OnMapEnd);
     assert_next!(v, TestEvent::OnDocumentEnd);
 }

--- a/tests/specexamples.rs.inc
+++ b/tests/specexamples.rs.inc
@@ -55,7 +55,7 @@ const EX2_18 : &'static str =
 // TODO: 2.19 - 2.22 schema tags
 
 const EX2_23 : &'static str =
-    "---\nnot-date: !!str 2002-04-28\n\npicture: !!binary |\n R0lGODlhDAAMAIQAAP//9/X\n 17unp5WZmZgAAAOfn515eXv\n Pz7Y6OjuDg4J+fn5OTk6enp\n 56enmleECcgggoBADs=\n\napplication specific tag: !something |\n The semantics of the tag\n above may be different for\n different documents.";
+    "---\nnot-date: !!str 2002-04-28\n\npicture: !!binary |\n R0lGODlhDAAMAIQAAP//9/X\n 17unp5WZmZgAAAOfn515eXv\n Pz7Y6OjuDg4J+fn5OTk6enp\n 56enmleECcgggoBADs=\n\napplication specific tag: !something |\n The semantics of the tag\n above may be different for\n different documents.\n\nscalar tag with value: !Ref reference\n";
 
 const EX2_24 : &'static str =
     "%TAG ! tag:clarkevans.com,2002:\n--- !shape\n  # Use the ! handle for presenting\n  # tag:clarkevans.com,2002:circle\n- !circle\n  center: &ORIGIN {x: 73, y: 129}\n  radius: 7\n- !line\n  start: *ORIGIN\n  finish: { x: 89, y: 102 }\n- !label\n  start: *ORIGIN\n  color: 0xFFEEBB\n  text: Pretty vector drawing.";

--- a/tests/specs/handler_spec_test.cpp
+++ b/tests/specs/handler_spec_test.cpp
@@ -339,6 +339,8 @@ TEST_F(HandlerSpecTest, Ex2_23_VariousExplicitTags) {
   EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:binary", 0,                                "R0lGODlhDAAMAIQAAP//9/X\n17unp5WZmZgAAAOfn515eXv\nPz7Y6OjuDg4J+fn5OTk6enp\n56enmleECcgggoBADs=\n"));
   EXPECT_CALL(handler, OnScalar(_, "?", 0, "application specific tag"));
   EXPECT_CALL(handler, OnScalar(_, "!something", 0,                                "The semantics of the tag\nabove may be different for\ndifferent documents."));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "scalar tag with value"));
+  EXPECT_CALL(handler, OnScalar(_, "!Ref", 0,                            "reference"));
   EXPECT_CALL(handler, OnMapEnd());
   EXPECT_CALL(handler, OnDocumentEnd());
   Parse(ex2_23);


### PR DESCRIPTION
This change is need to support https://github.com/dtolnay/serde-yaml/pull/220. It provides the needed propagation of tags for `SequenceStart` and `MappingStart` events. This allows consumers of these events using `MarkedEventReceiver` or `EventReceiver` to take advantage of the tags to reason mapping. 

In addition to the usage for serde-yaml show above, a usage when dealing with AWS CloudFormation templates can be seen [here][CFN].

Please note, this PR did not change the testing to also return events with tags contained as outline in issue #148. 

Issues: https://github.com/dtolnay/serde-yaml/issues/147, #147, I believe this also helps address #35 (need more verification here, but the examples provided are both implemented in https://github.com/dtolnay/serde-yaml/pull/220 pull and the [CloudFormation][CFN] provided above)

[CFN]: https://github.com/dchakrav-github/cloudformation-guard/commit/ece4620c811adb84ed4f3738a1ffcc7b2a44c0d4