### PR TITLE
Expose info() api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,13 @@ key1:a2
 ";
         assert!(YamlLoader::load_from_str(s).is_err());
         assert!(try_fail(s).is_err());
+        assert_eq!(
+            try_fail(s).unwrap_err().info(),
+            "mapping values are not allowed in this context"
+        );
+        assert_eq!(
+            try_fail(s).unwrap_err().to_string(),
+            "mapping values are not allowed in this context at line 4 column 4"
+        );
     }
-
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -60,6 +60,10 @@ impl ScanError {
     pub fn marker(&self) -> &Marker {
         &self.mark
     }
+
+    pub fn info(&self) -> &str {
+        self.info.as_ref()
+    }
 }
 
 impl Error for ScanError {


### PR DESCRIPTION
Add a function that exposes the `info` value. This is needed since [description()](https://doc.rust-lang.org/std/error/trait.Error.html#method.description) is deprecated.